### PR TITLE
Corrected name in .yaml files

### DIFF
--- a/jamovi/0000.yaml
+++ b/jamovi/0000.yaml
@@ -13,7 +13,7 @@ description: >-
   indenting paragraphs within the Description.
 analyses:
   - title: MannKendall test for trend analysis
-    name: MannKendall
+    name: mannkendall
     ns: TrendAnalysis
     menuGroup: TrendAnalysis
     menuTitle: MannKendall test for trend analysis

--- a/jamovi/mannkendall.a.yaml
+++ b/jamovi/mannkendall.a.yaml
@@ -1,5 +1,5 @@
 ---
-name:  MannKendall
+name:  mannkendall
 title: MannKendall test for trend analysis
 menuGroup: TrendAnalysis
 version: '1.0.0'

--- a/jamovi/mannkendall.r.yaml
+++ b/jamovi/mannkendall.r.yaml
@@ -1,5 +1,5 @@
 ---
-name:  MannKendall
+name:  mannkendall
 title: MannKendall test for trend analysis
 jrs:   '1.1'
 

--- a/jamovi/mannkendall.u.yaml
+++ b/jamovi/mannkendall.u.yaml
@@ -1,5 +1,5 @@
 title: MannKendall test for trend analysis
-name: MannKendall
+name: mannkendall
 jus: '3.0'
 stage: 0
 compilerMode: aggressive


### PR DESCRIPTION
`name:` in .yaml files want the same lower case name of your R6 class for parsing as in .b.r file.